### PR TITLE
Packaging and Flake8 cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@
 sudo: false
 
 language: python
-python:
-  - 3.6
-  - 3.5
-  - 3.4
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis
@@ -14,9 +10,12 @@ matrix:
   include:
     - python: 3.6
       env: TOXENV=flake8
+    - python: 3.6
+      env: TOXENV=py36
     - python: 3.7
       dist: xenial
       sudo: true
+      env: TOXENV=py37
 
 # Command to run tests, e.g. python setup.py test
 script: tox

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,2 +1,2 @@
 -i https://pypi.python.org/simple
--e .
+-e .[docs]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,13 @@
+[bdist_wheel]
+universal = 1
+
+[flake8]
+exclude = docs
+
+[aliases]
+# Define setup.py command aliases here
+test = pytest
+
+[tool:pytest]
+collect_ignore = ['setup.py']
+

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # Copyright (c) 2018, Red Hat, Inc.
 #   License: MIT
-import setuptools
-import re
-
-from toolchest import __version__
+from setuptools import setup, find_packages
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()
@@ -13,22 +10,18 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 
-def requires(prefix=''):
-    """Retrieve requirements from requirements.txt
-    """
-    try:
-        reqs = map(str.strip, open(prefix + 'requirements.txt').readlines())
-        reqs = filter(lambda s: re.match(r'\W', s), reqs)
-        return reqs
-    except Exception:
-        pass
-    return []
+TEST_REQUIRES = ['coverage', 'flake8', 'pytest', 'pytest-datadir', 'tox']
 
-
-setuptools.setup(
+setup(
     name='toolchest',
-    version=__version__,
-    install_requires=requires(),
+    version='0.0.2',
+    setup_requires=['pytest-runner'],
+    install_requires=[],
+    tests_require=TEST_REQUIRES,
+    extras_require={'test': TEST_REQUIRES,
+                    'docs': ['sphinx',
+                             'sphinx-autobuild',
+                             'sphinx-rtd-theme']},
     license='MIT',
     description=("toolchest is a collection of generic "
                  "functions for release-depot."),
@@ -37,17 +30,18 @@ setuptools.setup(
     author_email='lhh@redhat.com',
     maintainer='Lon Hohberger',
     maintainer_email='lon@metamorphism.com',
-    packages=['toolchest', 'toolchest.rpm'],
+    packages=find_packages(include=['toolchest.*']),
     url='http://github.com/release-depot/toolchest',
     data_files=[("", ["LICENSE"])],
+    test_suite='tests',
+    zip_safe=False,
     classifiers=['Development Status :: 4 - Beta',
                  'Intended Audience :: Developers',
                  'Natural Language :: English',
                  'Operating System :: POSIX :: Linux',
                  'Programming Language :: Python :: 3',
-                 'Programming Language :: Python :: 3.4',
-                 'Programming Language :: Python :: 3.5',
                  'Programming Language :: Python :: 3.6',
+                 'Programming Language :: Python :: 3.7',
                  'Topic :: Software Development',
                  'Topic :: Software Development :: Libraries',
                  'Topic :: Software Development :: Libraries :: Python Modules',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,13 +1,2 @@
-pip==9.0.1
-bumpversion==0.5.3
-wheel==0.30.0
-watchdog==0.8.3
-flake8==3.5.0
-tox==2.9.1
-coverage==4.5.1
-Sphinx==1.7.1
-sphinx-rtd-theme==0.4.1
-twine==1.10.0
-
-pytest==3.4.2
-pytest-runner==2.11.1
+-i https://pypi.python.org/simple
+-e .[test]

--- a/toolchest/decor.py
+++ b/toolchest/decor.py
@@ -117,8 +117,8 @@ class PrettyTable(object):
             return self.pt.add_row(row)
 
         if len(row) != len(self.cols):
-            raise ValueError('Row length is ' + str(len(row)) +
-                             ', but should be ' + str(len(self.cols)))
+            msg = 'Row length is {0}, but should be {1}'
+            raise ValueError(msg.format(str(len(row)), str(len(self.cols))))
         self.rows.append(row)
 
     def get_string(self):

--- a/toolchest/rpm/utils.py
+++ b/toolchest/rpm/utils.py
@@ -44,7 +44,7 @@ def splitFilename(nvr):
     arches = ['noarch', 'x86_64', 'i386', 'i486', 'i586',
               'i686', 'ppc', 'ppc64', 'ppc64le', 's390',
               's390x', 'aarch64', 'src']
-    arch_rx = '\.(' + '|'.join(arches) + ')$'
+    arch_rx = r'\.(' + '|'.join(arches) + ')$'
     if re.search(arch_rx, nvr):
         x = nvr.rfind('.')
         a = nvr[x + 1:]
@@ -131,13 +131,13 @@ def dlrn_label_compare(l, r):
     lv = l[1]
     lr = l[2]
 
-    dlrn_regex = '^0(\.[0-9]{1,2})?\.[0-9]{14}\.'
+    dlrn_regex = r'^0(\.[0-9]{1,2})?\.[0-9]{14}\.'
 
     if re.match(dlrn_regex, lr):
         l_is_dlrn = True
-    elif re.match('^0\.[0-9]{1,2}\.0rc[123](\.|$)', lr):
+    elif re.match(r'^0\.[0-9]{1,2}\.0rc[123](\.|$)', lr):
         l_is_rc = True
-    elif re.match('^0\.[0-9]{1,2}(\.|$)', lr):
+    elif re.match(r'^0\.[0-9]{1,2}(\.|$)', lr):
         l_is_ga = True
 
     rx = r[0]
@@ -146,9 +146,9 @@ def dlrn_label_compare(l, r):
 
     if re.match(dlrn_regex, rr):
         r_is_dlrn = True
-    elif re.match('^0\.[0-9]{1,2}\.0rc[123](\.|$)', rr):
+    elif re.match(r'^0\.[0-9]{1,2}\.0rc[123](\.|$)', rr):
         r_is_rc = True
-    elif re.match('^0\.[0-9]{1,2}(\.|$)', rr):
+    elif re.match(r'^0\.[0-9]{1,2}(\.|$)', rr):
         r_is_ga = True
 
     if r_is_dlrn == l_is_dlrn:

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,20 @@
 [tox]
-envlist = py34, py35, py36, py37, flake8
+envlist = py36, py37, flake8
 
 [travis]
 python =
     3.7: py37
     3.6: py36
-    3.5: py35
-    3.4: py34
 
 [testenv]
 passenv=HOME
 sitepackages = False
-deps = pytest
-commands = pytest
+whitelist_externals = python
+commands = python setup.py test
 
 [testenv:flake8]
 passenv=HOME
 sitepackages = False
 deps = flake8
 commands =
-    flake8 --ignore=E501 setup.py toolchest tests
+    flake8 --ignore=E501,W504 setup.py toolchest tests


### PR DESCRIPTION
Rotating the packaging to be a little more flexible.

Updating the packaging to better allow for adding dependencies and
managing everything through setup.py. Now the requirements files use the
data from setup.py directly without having to replicate data in two
places.

Updated tox to use the new layout correctly.

Dropping support for python 3.4 and 3.5 since 3.6 is more common. It
also allows for testing with newer versions of pytest and PyYAML. Adding
python 3.7 testing support.

Flake8 Cleanup.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>