### PR TITLE
Add generic build_repr method for property-based classes.

### DIFF
--- a/tests/unit/test_introspect.py
+++ b/tests/unit/test_introspect.py
@@ -1,0 +1,54 @@
+"""
+Test introspection methods
+"""
+
+import pytest  # NOQA
+from toolchest.introspect import build_repr, build_attrs, check_if_property
+
+
+class SomeClass(object):
+
+    def __init__(self, key1=None):
+        self._key1 = key1
+
+    @property
+    def key1(self):
+        return self._key1
+
+
+@pytest.fixture()
+def an_object():
+    return SomeClass()
+
+
+class TestCheckIfProperty(object):
+
+    def test_true_if_property(self, an_object):
+        assert check_if_property(an_object, 'key1') is True
+
+    def test_false_if_not_property(self, an_object):
+        SomeClass.not_a_key = 'some value'
+        assert check_if_property(an_object, 'not_a_key') is False
+
+
+class TestBuildAttrs(object):
+
+    def test_no_attrs(self, an_object):
+        attrs_dict = build_attrs(an_object)
+        assert an_object.key1 is None
+        assert attrs_dict.get('key1') is None
+
+    def test_returns_key_value_list(self):
+        obj = SomeClass(key1="farkle")
+        attrs_dict = build_attrs(obj)
+        assert obj.key1 == 'farkle'
+        assert attrs_dict.get('key1') == 'farkle'
+
+
+class TestBuildRepr(object):
+
+    def test_returns_string(self):
+        obj = SomeClass(key1="farkle")
+        obj_str = build_repr(obj)
+        expected = "SomeClass({'key1': 'farkle'})"
+        assert obj_str == expected

--- a/toolchest/introspect.py
+++ b/toolchest/introspect.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""
+Methods related to introspection of a class
+"""
+
+
+def check_if_property(instance, prop):
+    """
+    Check if a given value is a property on the specified class instance
+
+    :param instance: An instance of some class
+    :param prop: A value to check
+    :return: True or False
+    """
+    return isinstance(getattr(instance.__class__, prop), property)
+
+
+def build_attrs(instance):
+    """
+    Build a dict of attributes on a given instance
+
+    :param instance: An instance of some class
+    :return: Dict of all object attributes that are properties
+    """
+    return {prop: instance.__getattribute__(prop)
+            for prop in dir(type(instance)) if
+            check_if_property(instance, prop)}
+
+
+def build_repr(instance):
+    """
+    Generic way to implement a __repr__ method for classes using properties
+
+    :param instance: An instance of some class
+    :return: String that can be eval'ed to an object
+    """
+    return f"{type(instance).__name__}({build_attrs(instance)})"


### PR DESCRIPTION
This adds functionality to allow classes to optional build their __repr__ by
calling build_repr(self), instead of manually determining which properties
to expose in their __repr__ implementation.  Alternatively, one can call
build_repr(my_obj) and get the same value, so this can be used on
property-based objects where they implement __repr__ or not.