### PR TITLE
Accpet empty string as zero for epoch

### DIFF
--- a/tests/unit/test_rpmvercmp.py
+++ b/tests/unit/test_rpmvercmp.py
@@ -103,6 +103,18 @@ class TestLabelCompare(object):
         assert labelCompare(b, a) == 1
         assert labelCompare(b, b) == 0
 
+        # librpm seems to set '' to 0
+        a = ('', '1.0', '1')
+        b = ('1.0', '1')
+        c = (0, '1.0', '1')
+        d = ('0', '1.0', '1')
+        assert labelCompare(a, b) == 0
+        assert labelCompare(a, c) == 0
+        assert labelCompare(a, d) == 0
+        assert labelCompare(b, c) == 0
+        assert labelCompare(b, d) == 0
+        assert labelCompare(c, d) == 0
+
     def test_eq_epoch(self):
         a = ('1', '6.0.0', '2.el7ost')
         b = ('1', '6.0.1', '2.el7ost')

--- a/toolchest/rpm/rpmvercmp.py
+++ b/toolchest/rpm/rpmvercmp.py
@@ -165,7 +165,8 @@ def labelCompare(left, right):
     epoch_l = 0
     epoch_r = 0
     if len(left) == 3:
-        epoch_l = int(left[0])
+        if left[0] != '':
+            epoch_l = int(left[0])
         version_l = str(left[1])
         release_l = str(left[2])
     elif len(left) == 2:
@@ -175,7 +176,8 @@ def labelCompare(left, right):
         raise ValueError('left is not a tuple of 2 or 3')
 
     if len(right) == 3:
-        epoch_r = int(right[0])
+        if right[0] != '':
+            epoch_r = int(right[0])
         version_r = str(right[1])
         release_r = str(right[2])
     elif len(right) == 2:


### PR DESCRIPTION
Seems to be how librpm does it, and we want to
mirror that.

Signed-off-by: Lon Hohberger <lon@metamorphism.com>