### PR TITLE
Fix tox so tests pass.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,7 @@ TEST_REQUIRES = ['coverage', 'flake8', 'pytest', 'pytest-datadir', 'tox']
 setup(
     name='toolchest',
     version='0.0.6',
-    setup_requires=['pytest-runner'],
     install_requires=['pyyaml'],
-    tests_require=TEST_REQUIRES,
     extras_require={'test': TEST_REQUIRES,
                     'docs': ['sphinx',
                              'sphinx-autobuild',

--- a/tox.ini
+++ b/tox.ini
@@ -8,13 +8,17 @@ python =
 
 [testenv]
 passenv=HOME
+deps =
+    pytest
+    pytest-datadir
 sitepackages = False
 whitelist_externals = python
-commands = python setup.py test
+commands = pytest {posargs}
+
 
 [testenv:flake8]
 passenv=HOME
 sitepackages = False
 deps = flake8
 commands =
-    flake8 --ignore=E501,W504 setup.py toolchest tests
+    flake8 --ignore=E501,W504,E741 setup.py toolchest tests


### PR DESCRIPTION
Apparently we no longer need pytest-runner, so revamping config based
on https://tox.readthedocs.io/en/latest/example/pytest.html

Temporarily added a flake8 error to ignore, we can reenable later
if/when we decide to fix it (ambiguous variable name error).

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>