### PR TITLE
Add cpaas_label_compare

### DIFF
--- a/tests/test_rpmutils.py
+++ b/tests/test_rpmutils.py
@@ -8,6 +8,8 @@ from toolchest.rpm.utils import labelCompare
 # Compare vs. baseline
 from toolchest.rpm.rpmvercmp import labelCompare as rpmLabelCompare
 
+from toolchest.rpm.utils import cpaas_label_compare
+
 
 class test_split_filename(unittest.TestCase):
 
@@ -107,6 +109,27 @@ class test_split_filename(unittest.TestCase):
         self.assertEqual(rpmLabelCompare(b, f), 1)
         self.assertEqual(rpmLabelCompare(b, g), 1)
         self.assertEqual(labelCompare(b, f), -1)
+
+    def test_cpaas_label_compare(self):
+
+        a = ('0', '6.0.0', '2.el7ost')
+        b = ('0', '6.0.0', '3.el7ost')
+        c = ('0', '6.0.1', '0.20170.0rc1.el7ost')
+        d = ('0', '6.0.1', '1.20170.0rc1.el7ost')
+        e = ('0', '6.1.0', '1.20170.0rc1.el7ost')
+        f = ('', '6.1.0', '1.20170.0rc1.el7ost')
+
+        self.assertEqual(cpaas_label_compare(a, b), 0)
+        self.assertEqual(cpaas_label_compare(b, c), -1)
+        self.assertEqual(cpaas_label_compare(c, d), 0)
+        self.assertEqual(cpaas_label_compare(d, e), -1)
+        self.assertEqual(cpaas_label_compare(e, f), 0)
+
+        # if there's no divider, revert to normal label compare
+        a = ('0', '6.0.0', '2')
+        b = ('0', '6.0.0', '3')
+
+        self.assertEqual(cpaas_label_compare(a, b), -1)
 
 
 class test_drop_epoch(unittest.TestCase):

--- a/toolchest/rpm/utils.py
+++ b/toolchest/rpm/utils.py
@@ -211,6 +211,21 @@ def dlrn_label_compare(l, r):
     return (rpmLabelCompare((lx, lv, lr), (rx, rv, rr)), altered)
 
 
+def cpaas_label_compare(left, right):
+    if type(left) is not tuple or type(right) is not tuple:
+        raise ValueError('cpaas_label_compare requires two tuples')
+    if len(left) != 3 or len(right) != 3:
+        raise ValueError('cpaas_label_compare requires two tuples of length 3')
+
+    try:
+        l_r = left[2].split('.', 1)[1]
+        r_r = right[2].split('.', 1)[1]
+    except IndexError:
+        return rpmLabelCompare(left, right)
+
+    return rpmLabelCompare((left[0], left[1], l_r), (right[0], right[1], r_r))
+
+
 def label_compare(l, r):
     (ret, is_dlrn) = dlrn_label_compare(l, r)
     return ret


### PR DESCRIPTION
CPaaS rebuilds packages and bumps the major version number.  This
function is intended as a heuristic to compare two NVRs to see if
they match up - leaving out the major version number when doing
so.

Signed-off-by: Lon Hohberger <lhh@redhat.com>