### PR TITLE
cpaas_label_compare: Update for new CPaaS rules

### DIFF
--- a/tests/test_rpmutils.py
+++ b/tests/test_rpmutils.py
@@ -112,10 +112,10 @@ class test_split_filename(unittest.TestCase):
 
     def test_cpaas_label_compare(self):
 
-        a = ('0', '6.0.0', '2.el7ost')
-        b = ('0', '6.0.0', '3.el7ost')
-        c = ('0', '6.0.1', '0.20170.0rc1.el7ost')
-        d = ('0', '6.0.1', '1.20170.0rc1.el7ost')
+        a = ('0', '6.0.0', '3.el7ost.0')
+        b = ('0', '6.0.0', '3.el7ost.1')
+        c = ('0', '6.0.1', '1.20170.0rc1.el7ost')
+        d = ('0', '6.0.1', '1.20170.0rc1.el7ost.1')
         e = ('0', '6.1.0', '1.20170.0rc1.el7ost')
         f = ('', '6.1.0', '1.20170.0rc1.el7ost')
 
@@ -129,7 +129,14 @@ class test_split_filename(unittest.TestCase):
         a = ('0', '6.0.0', '2')
         b = ('0', '6.0.0', '3')
 
+        # Ignore divider if the main version changed
+        c = ('0', '6.0.0', '2.el7ost.0')
+        d = ('0', '6.0.0', '3.el7ost.0')
+        e = ('0', '6.0.0', '3.el7ost')
+
         self.assertEqual(cpaas_label_compare(a, b), -1)
+        self.assertEqual(cpaas_label_compare(c, d), -1)
+        self.assertEqual(cpaas_label_compare(c, e), -1)
 
 
 class test_drop_epoch(unittest.TestCase):

--- a/toolchest/rpm/utils.py
+++ b/toolchest/rpm/utils.py
@@ -217,11 +217,19 @@ def cpaas_label_compare(left, right):
     if len(left) != 3 or len(right) != 3:
         raise ValueError('cpaas_label_compare requires two tuples of length 3')
 
-    try:
-        l_r = left[2].split('.', 1)[1]
-        r_r = right[2].split('.', 1)[1]
-    except IndexError:
-        return rpmLabelCompare(left, right)
+    rx = re.compile(r'\.[0-9]+$')
+    l_m = rx.search(left[2])
+    r_m = rx.search(right[2])
+
+    if l_m:
+        l_r = left[2][0:l_m.span()[0]]
+    else:
+        l_r = left[2]
+
+    if r_m:
+        r_r = right[2][0:r_m.span()[0]]
+    else:
+        r_r = right[2]
 
     return rpmLabelCompare((left[0], left[1], l_r), (right[0], right[1], r_r))
 


### PR DESCRIPTION
Previously, CPaaS was updating the release number at the
front of the release. Now, it's appending a dot and a rebuild
count number after the dot (and possibly incrementing it).

So, update the comparison function to chop off the last dot - and
following number (if it exists) and compare using the truncated
version.

Signed-off-by: Lon Hohberger <lhh@redhat.com>