### PR TITLE
Use LGPL not GPL

### DIFF
--- a/toolchest/rpm/rpmvercmp.py
+++ b/toolchest/rpm/rpmvercmp.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 
 # (C) 2018 Red Hat, Inc.
-# License: Same as librpm: GPL version 2, or at your option,
-#          any later version.
+# License: Same as librpm: LGPL version 2
 
 
 # Python copy of rpmvercmp() from rpmvercmp.c


### PR DESCRIPTION
This file GPL notice conflicts with the the top level assertion 
that this LGPL. This is fixing this

See https://github.com/release-depot/toolchest/commit/16d7692218b379b6d7ed8af18b06187b5190864e#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7R25

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>