### PR TITLE
Fix doc generation for yaml.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../toolchest'))
+sys.path.insert(0, os.path.abspath('../'))
 
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
We had a config issue that was preventing sphinx from resolving
the import of the yaml library from toolchest,yaml.  Changing
how we set the path for sphinx seems to corrct this and not cause other
issues.

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>