### PR TITLE
Add missing 'dev' target to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,3 +80,7 @@ dist: clean ## builds source and wheel package
 
 install: clean ## install the package to the active Python's site-packages
 	python setup.py install
+
+dev: clean ## set up a development environment
+	pip3 install --user pipenv
+	pipenv install --dev


### PR DESCRIPTION
Currently, running the 'make dev' command results in:

$ make dev
make: *** No rule to make target 'dev'.  Stop.

The README mentions installing via `make dev` and that pipenv is installed via --user. Update the Makefile to match the README contents.

The targets and comments come from the git_wrapper Makefile.