### PR TITLE
Update mergify config to use queue instead of merge.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,15 +1,30 @@
+---
+
+queue_rules:
+  - name: default
+    conditions:
+      # Conditions to get out of the queue (= merged)
+      - check-success=flake8
+      - check-success=test (3.6)
+      - check-success=test (3.7)
+      - check-success=test (3.8)
+      - check-success=test (3.9)
+
 pull_request_rules:
-- actions:
-    merge:
-      method: rebase
-      rebase_fallback: merge
-      strict: true
-  conditions:
-    - label!=WIP
-    - '#approved-reviews-by>=2'
-    - check-success=flake8
-    - check-success=test (3.6)
-    - check-success=test (3.7)
-    - check-success=test (3.8)
-    - check-success=test (3.9)
-  name: default
+  - name: automatic merge
+    conditions:
+      - label!=WIP
+      - '#approved-reviews-by>=2'
+      # We have to duplicate these because mergify won't allow us to use an
+      # anchor
+      - check-success=flake8
+      - check-success=test (3.6)
+      - check-success=test (3.7)
+      - check-success=test (3.8)
+      - check-success=test (3.9)
+    actions:
+      queue:
+        method: rebase
+        rebase_fallback: merge
+        update_method: rebase
+        name: default


### PR DESCRIPTION
The old way of configuring merges has been deprecated since June
2021[1], so we need to move to the newer syntax.

[1] https://blog.mergify.com/strict-mode-deprecation/

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>