### PR TITLE
Update changelog generation tooling.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ release: dist ## package and upload a release
 	pipenv run twine upload dist/*
 
 dist: clean ## builds source and wheel package
+	rm -f CHANGELOG.md
 	pipenv run tox -etwine
 	ls -l dist
 

--- a/tooling/build_changelog
+++ b/tooling/build_changelog
@@ -3,8 +3,8 @@ the_dir=$1
 cd $the_dir
 pwd
 # We run the script twice.  First time it to create the base file:
-curl -s "https://raw.githubusercontent.com/release-depot/change/0.14.3/change" |
+curl -s "https://raw.githubusercontent.com/release-depot/change/latest/change" |
 sh -s -- init
 # Second time is to populate it with tag data:
-curl -s "https://raw.githubusercontent.com/release-depot/change/0.14.3/change" |
+curl -s "https://raw.githubusercontent.com/release-depot/change/latest/change" |
 sh -s --


### PR DESCRIPTION
This change pulls in a fix from the upstream change tool, and switches
to using a branch on our fork called 'latest' to enable us to pull any
fixes upstream into a branch, and automatically get them across all
other projects that use this tool.

Additionally, minor change to remove any previously generated
CHANGELOG.md before doing a local build.

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>