### PR TITLE
Fixed pylint errors E741 and E501 in flake8 in tox

### DIFF
--- a/tests/test_rpmutils.py
+++ b/tests/test_rpmutils.py
@@ -28,8 +28,13 @@ class test_split_filename(unittest.TestCase):
                 ('sos', '3.2', '36.el7ost.1', '', 'x86_64'))
         assert (split_filename('sos-3.2-36.el7ost.1.src.rpm') ==
                 ('sos', '3.2', '36.el7ost.1', '', ''))
-        assert (split_filename('openstack-nova-15.0.1-0.20170222170803.10a32dd.el7ost') ==  # NOQA
-                ('openstack-nova', '15.0.1', '0.20170222170803.10a32dd.el7ost', '', ''))   # NOQA
+        fn = 'openstack-nova-15.0.1-0.20170222170803.10a32dd.el7ost'
+        split_fn = ('openstack-nova',
+                    '15.0.1',
+                    '0.20170222170803.10a32dd.el7ost',
+                    '',
+                    '')
+        assert (split_filename(fn) == split_fn)
         assert (split_filename('openstack-nova-1:15.0.1-1.el7ost') ==
                 ('openstack-nova', '15.0.1', '1.el7ost', '1', ''))
 
@@ -59,10 +64,16 @@ class test_split_filename(unittest.TestCase):
                 ('', '1.2', '', '', ''))
 
     def test_absurd(self):
-        assert (split_filename('1:aarch64-ppc64le-i686-0.1-1.el7ost.src.rpm') ==
-                ('aarch64-ppc64le-i686', '0.1', '1.el7ost', '1', ''))
-        assert (split_filename('m-e-g-a-f-o-o-1.0-36.123.1333.elite.omg.long.el7ost.1.noarch.rpm') ==  # NOQA
-                ('m-e-g-a-f-o-o', '1.0', '36.123.1333.elite.omg.long.el7ost.1', '', 'noarch'))   # NOQA
+        whole_filename = '1:aarch64-ppc64le-i686-0.1-1.el7ost.src.rpm'
+        split_parts = ('aarch64-ppc64le-i686', '0.1', '1.el7ost', '1', '')
+        assert (split_filename(whole_filename) == split_parts)
+        fn = 'm-e-g-a-f-o-o-1.0-36.123.1333.elite.omg.long.el7ost.1.noarch.rpm'
+        split_fn = ('m-e-g-a-f-o-o',
+                    '1.0',
+                    '36.123.1333.elite.omg.long.el7ost.1',
+                    '',
+                    'noarch')
+        assert (split_filename(fn) == split_fn)
 
     def test_labelCompare(self):
 

--- a/toolchest/rpm/utils.py
+++ b/toolchest/rpm/utils.py
@@ -117,9 +117,10 @@ def split_filename(nvr):
     return splitFilename(nvr)
 
 
-def dlrn_label_compare(l, r):
-    warnings.warn("dlrn_label_compare() is deprecated; use label_compare().", DeprecationWarning)
-    if type(l) is not tuple or type(r) is not tuple:
+def dlrn_label_compare(left, right):
+    warnings.warn("dlrn_label_compare() is deprecated; use label_compare().",
+                  DeprecationWarning)
+    if type(left) is not tuple or type(right) is not tuple:
         raise ValueError('dlrn_label_compare requires two tuples')
 
     l_is_dlrn = False
@@ -129,9 +130,9 @@ def dlrn_label_compare(l, r):
     l_is_ga = False
     r_is_ga = False
 
-    lx = l[0]
-    lv = l[1]
-    lr = l[2]
+    lx = left[0]
+    lv = left[1]
+    lr = left[2]
 
     dlrn_regex = r'^[012](\.[0-9]{1,2})?\.[0-9]{14}\.[0-9a-f]{7}\.'
 
@@ -142,9 +143,9 @@ def dlrn_label_compare(l, r):
     elif re.match(r'^0\.[0-9]{1,2}(\.|$)', lr):
         l_is_ga = True
 
-    rx = r[0]
-    rv = r[1]
-    rr = r[2]
+    rx = right[0]
+    rv = right[1]
+    rr = right[2]
 
     if re.match(dlrn_regex, rr):
         r_is_dlrn = True
@@ -154,7 +155,7 @@ def dlrn_label_compare(l, r):
         r_is_ga = True
 
     if r_is_dlrn == l_is_dlrn:
-        return (rpmLabelCompare(l, r), False)
+        return (rpmLabelCompare(left, right), False)
 
     altered = False
     if l_is_dlrn:
@@ -236,13 +237,13 @@ def cpaas_label_compare(left, right):
     return rpmLabelCompare((left[0], left[1], l_r), (right[0], right[1], r_r))
 
 
-def label_compare(l, r):
-    return rpmLabelCompare(l, r)
+def label_compare(left, right):
+    return rpmLabelCompare(left, right)
 
 
 # Preserve old method name
-def labelCompare(l, r):
-    return label_compare(l, r)
+def labelCompare(left, right):
+    return label_compare(left, right)
 
 
 def drop_epoch(nevra):

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
 passenv=HOME
 sitepackages = False
 commands =
-    flake8 --ignore=E501,W504,E741 setup.py docs toolchest tests
+    flake8 setup.py docs toolchest tests
 
 [testenv:build]
 passenv =


### PR DESCRIPTION
Was able to fix E741 and E501 by fixing the tests. Since W504 is in the
default list of errors to ignore in flake8, simply removing the ignore
option in the flake8 command will revert to the default ignore list.