### PR TITLE
Fix pyproject.toml to match other projects.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,3 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools_scm]


### PR DESCRIPTION
For some reason, this file was slightly different here, and it was causing our CI publish to test pypi job to not honor the 'no-local-version' local_scheme setting, so it would do the standard dev approach of dev<number>+<githash>.

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>