### PR TITLE
Remove support for python 3.7.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+          python: ['3.8', '3.9', '3.10', '3.11']
       steps:
         - uses: actions/checkout@v3
         - name: Setup Python

--- a/toolchest/logging/drivers/default.py
+++ b/toolchest/logging/drivers/default.py
@@ -11,7 +11,7 @@ def getLogger(config):
 
     :param config:  Dictionary of values meeting the criteria in the
                     `Configuration dictionary schema
-                    <https://docs.python.org/3.7/library/logging.config.html#logging-config-dictschema>`_.
+                    <https://docs.python.org/3/library/logging.config.html#logging-config-dictschema>`_.
 
     """
     if 'version' not in config:


### PR DESCRIPTION
This version has been EOL as of June 27, 2023:
https://devguide.python.org/versions/

Also removed reference in a documentation link.